### PR TITLE
モデル・テーブルの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'devise'
 gem 'rails-i18n'
 gem 'devise-i18n'
 
+#列挙型
+gem 'enum_help'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.3)
       devise (>= 4.7.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -230,6 +232,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,0 +1,2 @@
+class Equipment < ApplicationRecord
+end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,4 +1,13 @@
 class Equipment < ApplicationRecord
   has_one :lending, dependent: :destroy
   belongs_to :registered_user, optional: true, class_name: "User"
+
+  enum genre: {
+    pc: 0,
+    note_pc: 1,
+    tera: 2,
+    camera: 3,
+    experiment: 4,
+    others: 5,
+  }
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -2,6 +2,12 @@ class Equipment < ApplicationRecord
   has_one :lending, dependent: :destroy
   belongs_to :registered_user, optional: true, class_name: "User"
 
+  validates :genre, presence: true
+  validates :lab_equipment_name, presence: true
+  validates :maker_name, presence: true
+  validates :product_name, presence: true
+  validates :purchase_year, presence: true
+
   enum genre: {
     pc: 0,
     note_pc: 1,

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,2 +1,3 @@
 class Equipment < ApplicationRecord
+  belongs_to :registered_user, optional: true, class_name: "User"
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,3 +1,4 @@
 class Equipment < ApplicationRecord
+  has_one :lending, dependent: :destroy
   belongs_to :registered_user, optional: true, class_name: "User"
 end

--- a/app/models/lending.rb
+++ b/app/models/lending.rb
@@ -1,0 +1,2 @@
+class Lending < ApplicationRecord
+end

--- a/app/models/lending.rb
+++ b/app/models/lending.rb
@@ -1,2 +1,4 @@
 class Lending < ApplicationRecord
+  belongs_to :lending_user, optional: true, class_name: "User"
+  belongs_to :borrowed_equipment, optional: true, class_name: "User"
 end

--- a/app/models/operation_history.rb
+++ b/app/models/operation_history.rb
@@ -1,2 +1,3 @@
 class OperationHistory < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/operation_history.rb
+++ b/app/models/operation_history.rb
@@ -1,3 +1,9 @@
 class OperationHistory < ApplicationRecord
   belongs_to :user
+
+  enum content: {
+    add_data: 0,
+    edit_data: 1,
+    delete_data: 2,
+  }
 end

--- a/app/models/operation_history.rb
+++ b/app/models/operation_history.rb
@@ -1,0 +1,2 @@
+class OperationHistory < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :equipments
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :authentication_keys => [:user_name]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
   has_many :equipments
+  has_many :lendings
+  has_many :operation_histories
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :authentication_keys => [:user_name]
 

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -8,3 +8,8 @@ ja:
         camera: "カメラ類"
         experiment: "実験機器"
         others: "その他"
+    operation_history:
+      content:
+        add_data: "追加しました"
+        edit_data: "編集しました"
+        delete_data: "削除しました"

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,10 @@
+ja:
+  enums:
+    equipment:
+      genre:
+        pc: "PC"
+        note_pc: "ノートPC"
+        tera: "テラステーション"
+        camera: "カメラ類"
+        experiment: "実験機器"
+        others: "その他"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,5 @@ ja:
     attributes:
       equipment:
         genre: 備品ジャンル
+      operation_history:
+        content: 操作履歴

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      equipment: 備品
+    attributes:
+      equipment:
+        genre: 備品ジャンル

--- a/db/migrate/20210425092307_devise_create_users.rb
+++ b/db/migrate/20210425092307_devise_create_users.rb
@@ -40,7 +40,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       t.timestamps null: false
     end
 
-    add_index :users, :email, unique: true
+    # add_index :users, :email, unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true

--- a/db/migrate/20210425104318_create_equipment.rb
+++ b/db/migrate/20210425104318_create_equipment.rb
@@ -1,0 +1,8 @@
+class CreateEquipment < ActiveRecord::Migration[6.1]
+  def change
+    create_table :equipment do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210425104318_create_equipment.rb
+++ b/db/migrate/20210425104318_create_equipment.rb
@@ -11,7 +11,7 @@ class CreateEquipment < ActiveRecord::Migration[6.1]
       t.integer :lendings_status, null: false, default: 0
       t.integer :disposal_status, null: false, default: 0
       t.text :remarks
-      t.references :registered_user, foreign_key: true, null: false
+      t.references :registered_user, null: false, foreign_key: { to_table: :users }
       t.timestamps
     end
   end

--- a/db/migrate/20210425104318_create_equipment.rb
+++ b/db/migrate/20210425104318_create_equipment.rb
@@ -1,7 +1,17 @@
 class CreateEquipment < ActiveRecord::Migration[6.1]
   def change
     create_table :equipment do |t|
-
+      t.integer :genre, null: false
+      t.string :lab_equipment_name, null: false
+      t.string :maker_name, null: false
+      t.string :product_name, null: false
+      t.integer :purchase_year, null: false
+      t.string :asset_num
+      t.integer :price
+      t.integer :lendings_status, null: false, default: 0
+      t.integer :disposal_status, null: false, default: 0
+      t.text :remarks
+      t.references :registered_user, foreign_key: true, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20210425104353_create_lendings.rb
+++ b/db/migrate/20210425104353_create_lendings.rb
@@ -1,0 +1,8 @@
+class CreateLendings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lendings do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210425104353_create_lendings.rb
+++ b/db/migrate/20210425104353_create_lendings.rb
@@ -1,7 +1,8 @@
 class CreateLendings < ActiveRecord::Migration[6.1]
   def change
     create_table :lendings do |t|
-
+      t.references :lending_user, null: false, foreign_key: { to_table: :users }
+      t.references :borrowed_equipment, null: false, foreign_key: { to_table: :equipments }
       t.timestamps
     end
   end

--- a/db/migrate/20210425104418_create_operation_histories.rb
+++ b/db/migrate/20210425104418_create_operation_histories.rb
@@ -1,0 +1,8 @@
+class CreateOperationHistories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :operation_histories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210425104418_create_operation_histories.rb
+++ b/db/migrate/20210425104418_create_operation_histories.rb
@@ -1,7 +1,9 @@
 class CreateOperationHistories < ActiveRecord::Migration[6.1]
   def change
     create_table :operation_histories do |t|
-
+      t.integer :content, null: false
+      t.string :lab_equipment_name, null: false
+      t.references :operated_user, null: false, foreign_key: { to_table: :users }
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_25_093237) do
+ActiveRecord::Schema.define(version: 2021_04_25_104418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "equipment", force: :cascade do |t|
+    t.integer "genre", null: false
+    t.string "lab_equipment_name", null: false
+    t.string "maker_name", null: false
+    t.string "product_name", null: false
+    t.integer "purchase_year", null: false
+    t.string "asset_num"
+    t.integer "price"
+    t.integer "lendings_status", default: 0, null: false
+    t.integer "disposal_status", default: 0, null: false
+    t.text "remarks"
+    t.bigint "registered_user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["registered_user_id"], name: "index_equipment_on_registered_user_id"
+  end
+
+  create_table "lendings", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "operation_histories", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.string "user_name"
-    t.string "last_name"
-    t.string "first_name"
-    t.integer "assignment_year"
+    t.string "user_name", null: false
+    t.string "last_name", null: false
+    t.string "first_name", null: false
+    t.integer "assignment_year", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "admin", default: false
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "equipment", "users", column: "registered_user_id"
 end

--- a/test/fixtures/equipment.yml
+++ b/test/fixtures/equipment.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/lendings.yml
+++ b/test/fixtures/lendings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/operation_histories.yml
+++ b/test/fixtures/operation_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EquipmentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/lending_test.rb
+++ b/test/models/lending_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LendingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/operation_history_test.rb
+++ b/test/models/operation_history_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OperationHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue番号
#3 

## 実装内容

- Equipmentモデルとequipmentsテーブルを作成
- Lendingモデルとlendingsテーブルを作成
- OperationHistoryモデルとoperation_historiesテーブルを作成
- 各テーブルの外部キー名を、意味がわかるように修正（[参考文献](https://qiita.com/HrsUed/items/2f8efba34453da633f75)）
- Equipmentモデルのカラム「genre」とOperationHistoryモデルの「content」は列挙型にする。
- バリデーションの追加