### PR TITLE
CSVエクスポート機能の実装

### DIFF
--- a/app/views/equipments/index.html.erb
+++ b/app/views/equipments/index.html.erb
@@ -13,6 +13,8 @@
   <%= f.submit "送信" %>
 <% end %>
 
+<%= link_to "CSVエクスポート",equipments_path(format: :csv) %>
+
 <table border = "1">
   <thead>
     <tr>


### PR DESCRIPTION
## issue番号
#6 
## 実装内容
- CSVエクスポート機能の実装（[参考文献](https://qiita.com/japwork/items/76fb527b1a49d93b7f83)）
  - equipmentsコントローラにCSVエクスポートアクションを追加
    - `CSV.generate`を用いて対象データをCSVデータに変換
  - 備品一覧表示ページに「CSVエクスポート」のリンクを追加
  - CSVファイル名に日付を追加