### PR TITLE
備品編集ページに「廃棄」のチェックボックスを作成

### DIFF
--- a/app/views/equipments/edit.html.erb
+++ b/app/views/equipments/edit.html.erb
@@ -36,6 +36,14 @@
         <%= f.label :remarks %>
         <%= f.text_area :remarks, class: "form-control"  %>
       </div>
+      <div class="custom-control custom-checkbox mb-4">
+        <% if @equipment.disposal_status == 0 %>
+          <%= f.check_box :disposal_status, class: "custom-control-input", checked: false ,checked_value: 1, unchecked_value: 0 %>
+        <% elsif @equipment.disposal_status == 1 %>
+          <%= f.check_box :disposal_status, class: "custom-control-input", checked: true ,checked_value: 1, unchecked_value: 0 %>
+        <% end %>
+        <%= f.label :disposal_status, class: "custom-control-label" %>
+      </div>
       <div class="actions mb-4">
         <%= f.submit "更新", class: "btn btn-primary form-control"  %>
       </div>

--- a/app/views/equipments/index.html.erb
+++ b/app/views/equipments/index.html.erb
@@ -3,8 +3,8 @@
   <%= render "equipments/new" %>
   <div class="col-12">
     <h1 class="text-center">備品データ一覧</h1>
-    <hr>
     <% if current_user.admin? %>
+      <hr>
       <span class="btn btn-secondary text-light mr-2" id="form-switch">備品データ追加</span>
       <%= link_to "CSVエクスポート",equipments_path(format: :csv), class: "btn btn-secondary text-light" %>
     <% else %>
@@ -51,14 +51,14 @@
             <td class="align-middle"><%= equipment.purchase_year %></td>
             <td class="align-middle"><%= equipment.asset_num %></td>
             <td class="align-middle">
-              <% if equipment.lendings_status == 0 %>
-                貸出可
-              <% elsif equipment.lendings_status == 1 %>
-                <span class="text-danger">貸出中</span>
-              <% end %>
               <% if equipment.disposal_status == 0 %>
+                <% if equipment.lendings_status == 0 %>
+                  貸出可
+                <% elsif equipment.lendings_status == 1 %>
+                  <span class="text-danger">貸出中</span>
+                <% end %>
               <% elsif equipment.disposal_status == 1 %>
-                <span class="text-danger">/ 廃棄済</span>
+                <span class="text-danger">廃棄済</span>
               <% end %>
             </td>
             <td class="align-middle">
@@ -68,17 +68,18 @@
               <% else %>
                 <%= link_to "詳細", equipment, class: "btn btn-primary text-light" %>
               <% end %>
-
-              <% if equipment.lendings_status == 0 %>
-                  <%= link_to "貸出", {controller: "lendings", action: "lending", id: equipment.id}, method: :post, class: "btn btn-primary text-light" %>
-              <% elsif equipment.lendings_status == 1 %>
+              <% if equipment.disposal_status == 0 %>
+                <% if equipment.lendings_status == 0 %>
+                    <%= link_to "貸出", {controller: "lendings", action: "lending", id: equipment.id}, method: :post, class: "btn btn-primary text-light" %>
+                <% elsif equipment.lendings_status == 1 %>
+                <% end %>
+              <% elsif equipment.disposal_status == 1 %>
               <% end %>
             </td>
           </tr>
         <% end %>
       </tbody>
     </table>
-
     <%= paginate @equipments %>
   </div>
 </div>

--- a/app/views/equipments/show.html.erb
+++ b/app/views/equipments/show.html.erb
@@ -64,13 +64,12 @@
         <tr scope="row">
           <td>ステータス</td>
           <td>
-            <% if @equipment.lendings_status == 0 %>
-              貸出可
-            <% elsif @equipment.lendings_status == 1 %>
-              <span class="text-danger">貸出中</span>
-            <% end %>
             <% if @equipment.disposal_status == 0 %>
-              未廃棄
+              <% if @equipment.lendings_status == 0 %>
+                貸出可
+              <% elsif @equipment.lendings_status == 1 %>
+                <span class="text-danger">貸出中</span>
+              <% end %>
             <% elsif @equipment.disposal_status == 1 %>
               <span class="text-danger">廃棄済み</span>
             <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
         purchase_year: 購入年度
         asset_num: 資産番号
         price: 値段
+        disposal_status: 廃棄
         remarks: 備考
       operation_history:
         content: 操作履歴


### PR DESCRIPTION
## issue番号
#20 

## 実装内容
- 備品編集ページに「廃棄」のチェックボックスを作成
  - チェックを入れて更新すると、備品のステータスが「廃棄済」となり、貸出を出来なくする