### PR TITLE
マイページの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :assignment_year])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:last_name, :first_name, :assignment_year])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :authentication_keys => [:user_name]
 
+  validates :user_name, uniqueness: true
+
   # No use email
   def email_required?
     false

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,34 +1,51 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<div class="row justify-content-center">
+  <div class="col-6">
+    <h1 class="text-center"><%= t('.title', resource: resource.model_name.human) %></h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+      <div class="field form-group">
+        <%= f.label :user_name %><br />
+        <%= f.text_field :user_name, autofocus: true, autocomplete: "user_name", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :last_name %><br />
+        <%= f.text_field :last_name, autocomplete: "last_name", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :first_name %><br />
+        <%= f.text_field :first_name, autocomplete: "first_name", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :assignment_year %><br />
+        <%= f.text_field :assignment_year, autocomplete: "assignment_year", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :password %> 
+        (<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)
+        <%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= f.label :current_password %>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t('.update'), class: "btn btn-primary form-control" %>
+      </div>
     <% end %>
+
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.update') %>
-  </div>
-<% end %>
-
-<h3><%= t('.cancel_my_account') %></h3>
-
-<p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
-
-<%= link_to t('devise.shared.links.back'), :back %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-center">
   <div class="col-6">
-    <h1 class="text-center"><%= t('.title', resource: resource.model_name.human) %></h1>
+    <h1 class="text-center">アカウント編集</h1>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,15 +4,6 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
-  <% end %>
-
-  <div class="field">
     <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>

--- a/app/views/equipments/show.html.erb
+++ b/app/views/equipments/show.html.erb
@@ -39,7 +39,12 @@
         </tr>
         <tr scope="row">
           <td>データ作成者</td>
-          <td><%= @equipment.registered_user.user_name %>（<%= @equipment.registered_user.last_name %><%= @equipment.registered_user.first_name %>）</td>
+          <td>
+            <%= @equipment.registered_user.assignment_year %>年度配属
+            <%= @equipment.registered_user.last_name %>
+            <%= @equipment.registered_user.first_name %>
+            （<%= @equipment.registered_user.user_name %>）
+          </td>
         </tr>
         <tr scope="row">
           <td>データ作成日時</td>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,6 +7,7 @@
     <% if user_signed_in? %>
       <div class="navbar-nav mr-auto">
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
+        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active"  %>
         <%= link_to "備品データ一覧", equipments_path, class: "nav-item nav-link active" %>
         <%= link_to "貸出状況", lendings_path, class: "nav-item nav-link active" %>
         <%= link_to "貸出履歴", lendings_history_path, class: "nav-item nav-link active" %>

--- a/app/views/lendings/lendings_history.html.erb
+++ b/app/views/lendings/lendings_history.html.erb
@@ -23,6 +23,7 @@
             <td class="align-middle"><%= lending.borrowed_equipment.product_name %></td>
             <td class="align-middle"><%= lending.borrowed_equipment.purchase_year %></td>
             <td class="align-middle">
+              <%= lending.lending_user.assignment_year %>年度配属
               <%= lending.lending_user.last_name %>
               <%= lending.lending_user.first_name %>
             </td>

--- a/app/views/operation_histories/index.html.erb
+++ b/app/views/operation_histories/index.html.erb
@@ -15,6 +15,7 @@
         <% @operation_histories.each do |operation_history| %>
           <tr>
             <td>
+              <%= operation_history.operated_user.assignment_year %>年度配属
               <%= operation_history.operated_user.last_name %>
               <%= operation_history.operated_user.first_name %>
             </td>

--- a/db/migrate/20210425092307_devise_create_users.rb
+++ b/db/migrate/20210425092307_devise_create_users.rb
@@ -32,7 +32,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
-      t.string :user_name, null: false
+      t.string :user_name, null: false, unique: true
       t.string :last_name, null: false
       t.string :first_name, null: false
       t.integer :assignment_year, null: false


### PR DESCRIPTION
## issue番号
#22 
## 実装内容
- アカウント編集ページの実装
  - ユーザー名、研究室配属年度、氏名、パスワードを編集できる 
  - ナビバーにアカウント編集ページへのリンクを追加
  - アカウント編集ページのデザイン（Bootstrap）