### PR TITLE
フィードバックによる修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,12 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def exist_equipment?
+    unless Equipment.find_by(id: params[:id])
+      redirect_to root_path, alert: "備品id:#{params[:id]}は存在しません"
+    end
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :assignment_year])
     devise_parameter_sanitizer.permit(:account_update, keys: [:last_name, :first_name, :assignment_year])

--- a/app/controllers/equipments_controller.rb
+++ b/app/controllers/equipments_controller.rb
@@ -1,6 +1,8 @@
 class EquipmentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :correct_equipment,only: [:edit, :update, :destroy]
+  before_action :exist_equipment?, only: [:show, :edit, :update, :destroy] 
+  before_action :correct_equipment, only: [:edit, :update, :destroy]
+
   require "csv"
 
   PER_PAGE = 20

--- a/app/controllers/equipments_controller.rb
+++ b/app/controllers/equipments_controller.rb
@@ -78,7 +78,7 @@ class EquipmentsController < ApplicationController
     csv_data = CSV.generate do |csv|
       column_names = %w(備品ジャンル 研究室用備品名 メーカー名 製品名 購入年度 資産番号 値段 データ追加日 データ追加者 備考)
       csv << column_names
-      equipments.each do |equipment|
+      equipments.includes(:registered_user).each do |equipment|
         column_values = [
           equipment.genre_i18n,
           equipment.lab_equipment_name,

--- a/app/controllers/equipments_controller.rb
+++ b/app/controllers/equipments_controller.rb
@@ -1,5 +1,6 @@
 class EquipmentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :correct_equipment,only: [:edit, :update, :destroy]
   require "csv"
 
   PER_PAGE = 20
@@ -23,7 +24,6 @@ class EquipmentsController < ApplicationController
   end
 
   def edit
-    @equipment = Equipment.find(params[:id])
   end
 
   def create
@@ -40,7 +40,6 @@ class EquipmentsController < ApplicationController
   end
 
   def update
-    @equipment = Equipment.find(params[:id])
     OperationHistory.create_log(current_user.id, @equipment.lab_equipment_name, 1)
     if @equipment.update(equipment_params)
       redirect_to equipment_path(params[:id]), notice: "データを更新しました"
@@ -51,9 +50,8 @@ class EquipmentsController < ApplicationController
   end
 
   def destroy
-    equipment = Equipment.find(params[:id])
-    equipment.destroy!
-    OperationHistory.create_log(current_user.id, equipment.lab_equipment_name, 2)
+    @equipment.destroy!
+    OperationHistory.create_log(current_user.id, @equipment.lab_equipment_name, 2)
     redirect_to root_path, alert: "データを削除しました"
   end
 
@@ -72,6 +70,11 @@ class EquipmentsController < ApplicationController
       :disposal_status,
       :remarks
     )
+  end
+
+  def correct_equipment
+    redirect_to root_path, alert: "権限がありません" unless current_user.admin
+    @equipment = Equipment.find(params[:id])
   end
 
   def send_equipments_csv(equipments)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :ensure_normal_user, only: :update
+
+  def ensure_normal_user
+    if resource.user_name == "guest_user"
+      redirect_to root_path, alert: "ゲストユーザーの更新はできません。"
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
 module ApplicationHelper
+  def equipment_status(equipment)
+    if equipment.disposal_status == 0
+      if equipment.lendings_status == 0
+        content_tag(:span, "貸出可")
+      elsif equipment.lendings_status == 1
+        content_tag(:span, "貸出中", class: "text-danger")
+      end
+    elsif equipment.disposal_status == 1
+        content_tag(:span, "廃棄済", class: "text-danger")
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   end
 
   def self.guest
-    find_or_create_by!(user_name: "guest_user", last_name: "ゲスト", first_name: "太郎", assignment_year: 2021, admin: true) do |user|
+    find_or_create_by!(user_name: "guest_user", last_name: "ゲスト", first_name: "太郎", assignment_year: Time.current.year, admin: true) do |user|
       user.password = SecureRandom.urlsafe_base64
     end
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,7 +22,7 @@
 
       <div class="field form-group">
         <%= f.label :assignment_year %><br />
-        <%= f.text_field :assignment_year, autocomplete: "assignment_year", class: "form-control" %>
+        <%= f.select :assignment_year, options_for_select((1990..Time.current.year).to_a, selected: Time.current.year), {}, class: "form-control"  %>
       </div>
       
       <div class="field form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -40,6 +40,7 @@
 
       <div class="actions">
         <%= f.submit t('.sign_up') , class: "btn btn-primary form-control" %>
+        <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "btn btn-primary form-control mt-4" %>
       </div>
     <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,7 +21,9 @@
       <% end %>
 
       <div class="actions">
-        <%= f.submit t('.sign_in'), class: "btn btn-primary form-control"  %>
+        <%= f.submit t('.sign_in'), class: "btn btn-primary form-control" %>
+        <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "btn btn-primary form-control mt-4" %>
+      </div>
       </div>
     <% end %>
   </div>

--- a/app/views/equipments/_new.html.erb
+++ b/app/views/equipments/_new.html.erb
@@ -31,7 +31,7 @@
       </div>
       <div class="field form-group">
         <%= f.label :purchase_year %>（必須）
-        <%= f.select :purchase_year, options_for_select((1990..2100).to_a), {}, class: "form-control"  %>
+        <%= f.select :purchase_year, options_for_select((1990..Time.current.year).to_a, selected: Time.current.year), {}, class: "form-control"  %>
       </div>
       <div class="field form-group">
         <%= f.label :remarks %>

--- a/app/views/equipments/edit.html.erb
+++ b/app/views/equipments/edit.html.erb
@@ -30,7 +30,7 @@
       </div>
       <div class="field form-group">
         <%= f.label :purchase_year %>（必須）
-        <%= f.select :purchase_year, options_for_select((1990..2100).to_a), {}, class: "form-control"  %>
+        <%= f.select :purchase_year, options_for_select((1990..Time.current.year).to_a, selected: @equipment.purchase_year), {}, class: "form-control"  %>
       </div>
       <div class="field form-group">
         <%= f.label :remarks %>

--- a/app/views/equipments/index.html.erb
+++ b/app/views/equipments/index.html.erb
@@ -51,29 +51,15 @@
             <td class="align-middle"><%= equipment.purchase_year %></td>
             <td class="align-middle"><%= equipment.asset_num %></td>
             <td class="align-middle">
-              <% if equipment.disposal_status == 0 %>
-                <% if equipment.lendings_status == 0 %>
-                  貸出可
-                <% elsif equipment.lendings_status == 1 %>
-                  <span class="text-danger">貸出中</span>
-                <% end %>
-              <% elsif equipment.disposal_status == 1 %>
-                <span class="text-danger">廃棄済</span>
-              <% end %>
+              <%= equipment_status(equipment) %>
             </td>
             <td class="align-middle text-left">
+              <%= link_to "詳細", equipment_path(equipment), class: "btn btn-primary text-light" %>
               <% if current_user.admin? %>
-                <%= link_to "詳細", equipment_path(equipment), class: "btn btn-primary text-light" %>
                 <%= link_to "編集", edit_equipment_path(equipment), class: "btn btn-secondary text-light" %>
-              <% else %>
-                <%= link_to "詳細", equipment, class: "btn btn-primary text-light" %>
               <% end %>
-              <% if equipment.disposal_status == 0 %>
-                <% if equipment.lendings_status == 0 %>
-                    <%= link_to "貸出", {controller: "lendings", action: "lending", id: equipment.id}, method: :post, class: "btn btn-primary text-light" %>
-                <% elsif equipment.lendings_status == 1 %>
-                <% end %>
-              <% elsif equipment.disposal_status == 1 %>
+              <% if equipment.disposal_status == 0 && equipment.lendings_status == 0 %>
+                <%= link_to "貸出", {controller: "lendings", action: "lending", id: equipment.id}, method: :post, class: "btn btn-primary text-light" %>
               <% end %>
             </td>
           </tr>

--- a/app/views/equipments/index.html.erb
+++ b/app/views/equipments/index.html.erb
@@ -34,12 +34,12 @@
       <thead>
         <tr>
           <th scope="col" style="width:13%"><%= sort_link(@q, :genre, "備品ジャンル") %></th>
-          <th scope="col" style="width:15%"><%= sort_link(@q, :lab_equipment_name, "研究室用備品名") %></th>
+          <th scope="col" style="width:19%"><%= sort_link(@q, :lab_equipment_name, "研究室用備品名") %></th>
           <th scope="col" style="width:18%"><%= sort_link(@q, :product_name, "製品名") %></th>
           <th scope="col" style="width:10%"><%= sort_link(@q, :purchase_year, "購入年度") %></th>
           <th scope="col" style="width:12%"><%= sort_link(@q, :asset_num, "資産番号") %></th>
-          <th scope="col" style="width:12%">ステータス</th>
-          <th scope="col" style="width:20%"></th>
+          <th scope="col" style="width:10%">ステータス</th>
+          <th scope="col" style="width:18%"></th>
         </tr>
       </thead>
       <tbody>
@@ -61,7 +61,7 @@
                 <span class="text-danger">廃棄済</span>
               <% end %>
             </td>
-            <td class="align-middle">
+            <td class="align-middle text-left">
               <% if current_user.admin? %>
                 <%= link_to "詳細", equipment_path(equipment), class: "btn btn-primary text-light" %>
                 <%= link_to "編集", edit_equipment_path(equipment), class: "btn btn-secondary text-light" %>

--- a/app/views/equipments/show.html.erb
+++ b/app/views/equipments/show.html.erb
@@ -69,15 +69,7 @@
         <tr scope="row">
           <td>ステータス</td>
           <td>
-            <% if @equipment.disposal_status == 0 %>
-              <% if @equipment.lendings_status == 0 %>
-                貸出可
-              <% elsif @equipment.lendings_status == 1 %>
-                <span class="text-danger">貸出中</span>
-              <% end %>
-            <% elsif @equipment.disposal_status == 1 %>
-              <span class="text-danger">廃棄済み</span>
-            <% end %>
+            <%= equipment_status(@equipment) %>
           </td>
         </tr>
       </tbody>

--- a/app/views/equipments/show.html.erb
+++ b/app/views/equipments/show.html.erb
@@ -86,5 +86,6 @@
       <%= link_to "編集", edit_equipment_path(@equipment), class: "btn btn-primary form-control" %>
     <% else %>
     <% end %>
+    <%= link_to "備品一覧ページに戻る", equipments_path, class: "btn btn-primary form-control mt-4" %>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,7 +29,6 @@
       <div class="navbar-nav mr-auto">
         <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
         <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-        <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
       </div>
     <% end %>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,24 +6,24 @@
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
     <% if user_signed_in? %>
       <div class="navbar-nav mr-auto">
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-item nav-link active" %>
-        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active"  %>
         <%= link_to "備品データ一覧", equipments_path, class: "nav-item nav-link active" %>
         <%= link_to "貸出状況", lendings_path, class: "nav-item nav-link active" %>
         <%= link_to "貸出履歴", lendings_history_path, class: "nav-item nav-link active" %>
         <%= link_to "操作履歴", operation_history_path, class: "nav-item nav-link active" %>
       </div>
       <div class="navbar-nav">
-      <span class="navbar-text">
-        現在のアカウント:
-        <%= current_user.last_name %>
-        <%= current_user.first_name %>
-        （<%= current_user.user_name %>）
-        <% if current_user.admin? %>
-          / 管理者権限有り
-        <% else %>
-        <% end %>
-      </span>
+        <span class="navbar-text">
+          現在のアカウント:
+          <%= current_user.last_name %>
+          <%= current_user.first_name %>
+          （<%= current_user.user_name %>）
+          <% if current_user.admin? %>
+            / 管理者権限有り
+          <% else %>
+          <% end %>
+        </span>
+          <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link active" %>
+          <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-link active"  %>
       </div>
     <% else %>
       <div class="navbar-nav mr-auto">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   patch "/lendings/:id", to: "lendings#return"
   get "/lendings/history", to: "lendings#lendings_history"
   get "operation_history/", to: "operation_histories#index"
-  devise_for :users
+  devise_for :users, controllers: {
+                       registrations: "users/registrations",
+                     }
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end


### PR DESCRIPTION
## issue番号
#28 

## 実装内容
- ゲストログインを分かりやすい位置に配置
- 新規登録画面の研究室配属年度をコンボボックス形式に修正
- 購入年度のセレクタボックスから未来の年度を削除
- 備品データ一覧の詳細・貸出ボタンの位置を左寄せに修正
- 詳細ページに戻るボタンを設置
- アカウント編集ページ（ゲストログイン）で更新ボタンを押すと、確認用のパスワードが求められるエラーの修正
- CSVエクスポート時のN + 1問題を解決
- 編集権限がないユーザがedit, update, destroyアクションを実行できないように修正
- 存在しないデータにアクセスした際の処理
- viewページのステータスの表示の分岐処理にヘルパーを使う
- 備品詳細で、備品のレンタル履歴を表示・その場で返却可にする