### PR TITLE
CSVエクスポートファイル名の時差を修正

### DIFF
--- a/app/controllers/equipments_controller.rb
+++ b/app/controllers/equipments_controller.rb
@@ -99,7 +99,7 @@ class EquipmentsController < ApplicationController
         csv << column_values
       end
     end
-    time = Time.now
+    time = Time.zone.now
     send_data(csv_data, filename: "#{time.year}年#{time.month}月#{time.day}日#{time.hour}時#{time.min}分#{time.sec}秒時点_備品一覧.csv")
     OperationHistory.create_log(current_user.id, "備品データ", 3)
   end


### PR DESCRIPTION
# 実装内容
- CSVエクスポートファイル名の時差を修正
- `Time.now`→`Time.zone.now`に修正